### PR TITLE
점심 메뉴 API

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -52,7 +52,7 @@
             "position": "after"
           },
           {
-            "pattern": "@Pages/*",
+            "pattern": "@Pages/**/*",
             "group": "internal",
             "position": "after"
           },
@@ -68,6 +68,11 @@
           },
           {
             "pattern": "@Styles/*",
+            "group": "internal",
+            "position": "after"
+          },
+          {
+            "pattern": "@Types/*",
             "group": "internal",
             "position": "after"
           }

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,9 +1,9 @@
-import SignIn from '@Pages/Auth/SignIn';
 import { Routes, BrowserRouter, Route } from 'react-router-dom';
 
 import ROUTE_PATH from '@Constant/routePath';
 
 import Auth from '@Pages/Auth';
+import SignIn from '@Pages/Auth/SignIn';
 
 function Router() {
   return (

--- a/src/components/SummaryList/SummaryItems/index.tsx
+++ b/src/components/SummaryList/SummaryItems/index.tsx
@@ -1,0 +1,41 @@
+import * as S from './style';
+import type { SummaryList } from '../type';
+
+function SummaryItems({
+  list,
+  isLoading,
+  guideMessage,
+}: Pick<SummaryList, 'list' | 'isLoading' | 'guideMessage'>) {
+  if (isLoading) {
+    return (
+      <>
+        {Array.from({ length: 4 }).map((_, index) => (
+          <S.SummaryItem key={index}>
+            <S.SummaryText isLoading={isLoading}>Loading</S.SummaryText>
+          </S.SummaryItem>
+        ))}
+      </>
+    );
+  }
+
+  if (!list) {
+    return (
+      <S.NoSummaryItem>
+        <S.NoSummaryMessage>정보가 없습니다.</S.NoSummaryMessage>
+        <S.NoSummaryGuideMessage>{guideMessage}</S.NoSummaryGuideMessage>
+      </S.NoSummaryItem>
+    );
+  }
+
+  return (
+    <>
+      {list.map((summary, index) => (
+        <S.SummaryItem key={index}>
+          <S.SummaryText>{summary}</S.SummaryText>
+        </S.SummaryItem>
+      ))}
+    </>
+  );
+}
+
+export default SummaryItems;

--- a/src/components/SummaryList/SummaryItems/style.ts
+++ b/src/components/SummaryList/SummaryItems/style.ts
@@ -1,0 +1,40 @@
+import styled from 'styled-components';
+
+import { TextSkeletonStyle } from '@Styles/skeleton';
+
+import { SummaryTextProps } from '../type';
+
+export const SummaryItem = styled.li`
+  padding: 1.5rem 0rem;
+  border-top: 0.05rem solid #e2e2e2;
+
+  line-height: 160%;
+
+  :last-child {
+    padding-bottom: 0rem;
+  }
+`;
+
+export const SummaryText = styled.div<SummaryTextProps>`
+  line-height: 160%;
+
+  ${({ isLoading }) => isLoading && TextSkeletonStyle}
+`;
+
+export const NoSummaryItem = styled.div`
+  padding: 4rem;
+  border-top: 0.05rem solid #e2e2e2;
+
+  text-align: center;
+`;
+
+export const NoSummaryMessage = styled.div`
+  margin-bottom: 1rem;
+
+  font-weight: 700;
+`;
+
+export const NoSummaryGuideMessage = styled.div`
+  color: ${({ theme }) => theme.subText};
+  line-height: 160%;
+`;

--- a/src/components/SummaryList/SummaryList.stories.tsx
+++ b/src/components/SummaryList/SummaryList.stories.tsx
@@ -8,7 +8,7 @@ type Story = StoryObj<typeof SummaryList>;
  * `SummaryList`은 어떤 주제에 대한 정보를 간단히 나타내고 싶을 때 사용되는 컴포넌트입니다.
  */
 const meta: Meta<typeof SummaryList> = {
-  title: 'SummaryList',
+  title: 'List/SummaryList',
   component: SummaryList,
 };
 

--- a/src/components/SummaryList/SummaryList.stories.tsx
+++ b/src/components/SummaryList/SummaryList.stories.tsx
@@ -47,7 +47,6 @@ export const LongSummaryList: Story = {
 export const NoExistListSummaryList: Story = {
   args: {
     title: '요약 정보의 타이틀',
-    list: [],
     guideMessage: '어떤 조치를 취해주세요.',
     width: '320px',
   },
@@ -60,5 +59,6 @@ export const SkeletonListSummaryList: Story = {
   args: {
     title: '요약 정보의 타이틀',
     width: '320px',
+    isLoading: true,
   },
 };

--- a/src/components/SummaryList/index.tsx
+++ b/src/components/SummaryList/index.tsx
@@ -1,3 +1,4 @@
+import SummaryItems from './SummaryItems';
 import * as S from './style';
 import type { SummaryList } from './type';
 
@@ -5,30 +6,18 @@ function SummaryList({
   title,
   list,
   guideMessage,
+  isLoading,
   width = '100%',
 }: SummaryList) {
   return (
     <S.Layout width={width}>
       <S.Title>{title}</S.Title>
       <S.SummaryList>
-        {!list ? (
-          Array.from({ length: 4 }).map((_, index) => (
-            <S.SummaryItem key={index}>
-              <S.SummaryText isLoading>Loading</S.SummaryText>
-            </S.SummaryItem>
-          ))
-        ) : list.length ? (
-          list.map((summary, index) => (
-            <S.SummaryItem key={index}>
-              <S.SummaryText>{summary}</S.SummaryText>
-            </S.SummaryItem>
-          ))
-        ) : (
-          <S.NoSummaryItem>
-            <S.NoSummaryMessage>정보가 없습니다.</S.NoSummaryMessage>
-            <S.NoSummaryGuideMessage>{guideMessage}</S.NoSummaryGuideMessage>
-          </S.NoSummaryItem>
-        )}
+        <SummaryItems
+          list={list}
+          isLoading={isLoading}
+          guideMessage={guideMessage}
+        />
       </S.SummaryList>
     </S.Layout>
   );

--- a/src/components/SummaryList/style.ts
+++ b/src/components/SummaryList/style.ts
@@ -1,8 +1,6 @@
 import styled from 'styled-components';
 
-import { TextSkeletonStyle } from '@Styles/skeleton';
-
-import type { LayoutProps, SummaryTextProps } from './type';
+import type { LayoutProps } from './type';
 
 export const Layout = styled.div<LayoutProps>`
   display: grid;
@@ -28,39 +26,4 @@ export const Title = styled.div`
 
 export const SummaryList = styled.ul`
   display: grid;
-`;
-
-export const SummaryItem = styled.li`
-  padding: 1.5rem 0rem;
-  border-top: 0.05rem solid #e2e2e2;
-
-  line-height: 160%;
-
-  :last-child {
-    padding-bottom: 0rem;
-  }
-`;
-
-export const SummaryText = styled.div<SummaryTextProps>`
-  line-height: 160%;
-
-  ${({ isLoading }) => isLoading && TextSkeletonStyle}
-`;
-
-export const NoSummaryItem = styled.div`
-  padding: 4rem;
-  border-top: 0.05rem solid #e2e2e2;
-
-  text-align: center;
-`;
-
-export const NoSummaryMessage = styled.div`
-  margin-bottom: 1rem;
-
-  font-weight: 700;
-`;
-
-export const NoSummaryGuideMessage = styled.div`
-  color: ${({ theme }) => theme.subText};
-  line-height: 160%;
 `;

--- a/src/components/SummaryList/type.ts
+++ b/src/components/SummaryList/type.ts
@@ -3,6 +3,7 @@ type SummaryList = {
   list?: string[];
   guideMessage?: string;
   width?: string;
+  isLoading: boolean;
 };
 
 type LayoutProps = {

--- a/src/components/WeatherBadge/WeatherBadge.stories.tsx
+++ b/src/components/WeatherBadge/WeatherBadge.stories.tsx
@@ -10,7 +10,7 @@ type Story = StoryObj<typeof WeatherBadge>;
  * `WeatherBadge`은 현재 날씨, 미세먼지를 간략하게 나타내는 컴포넌트입니다.
  */
 const meta: Meta<typeof WeatherBadge> = {
-  title: 'WeatherBadge',
+  title: 'Badge/WeatherBadge',
   component: WeatherBadge,
 };
 
@@ -39,8 +39,15 @@ export const RejectWeatherBadge: Story = {
 };
 
 /**
+ * 날씨 정보가 없을 때의 `WeatherBadge`의 스토리입니다.
+ */
+export const NoneWeatherBadge: Story = {
+  args: {},
+};
+
+/**
  * 날씨 정보가 불러오는 동안 보여지는 `WeatherBadge`의 스토리입니다.
  */
 export const SkeletonWeatherBadge: Story = {
-  args: {},
+  args: { isLoading: true },
 };

--- a/src/components/WeatherBadge/index.tsx
+++ b/src/components/WeatherBadge/index.tsx
@@ -1,20 +1,42 @@
 import * as S from './style';
 import type { WeatherBadge } from './type';
 
-function WeatherBadge({ weather, isRejected = false }: WeatherBadge) {
+function WeatherBadge({
+  weather,
+  isRejected = false,
+  isLoading,
+}: WeatherBadge) {
+  if (isRejected) {
+    return (
+      <S.Layout>
+        <S.RejectMessage>위치 정보 없음</S.RejectMessage>
+      </S.Layout>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <S.Layout>
+        <S.Container isLoading>로딩중</S.Container>
+      </S.Layout>
+    );
+  }
+
+  if (!weather) {
+    return (
+      <S.Layout>
+        <S.Container>날씨 정보 없음</S.Container>
+      </S.Layout>
+    );
+  }
+
   return (
     <S.Layout>
-      {isRejected ? (
-        <S.RejectMessage>위치 정보 없음</S.RejectMessage>
-      ) : !weather ? (
-        <S.Container isLoading>로딩중</S.Container>
-      ) : (
-        <S.Container>
-          <S.WeatherIcon src={weather.sky} />
-          <S.Temperature>{weather.temperature}</S.Temperature>
-          <S.Dust>{weather.dust}</S.Dust>
-        </S.Container>
-      )}
+      <S.Container>
+        <S.WeatherIcon src={weather.sky} />
+        <S.Temperature>{weather.temperature}</S.Temperature>
+        <S.Dust>{weather.dust}</S.Dust>
+      </S.Container>
     </S.Layout>
   );
 }

--- a/src/components/WeatherBadge/type.ts
+++ b/src/components/WeatherBadge/type.ts
@@ -7,6 +7,7 @@ type Weather = {
 type WeatherBadge = {
   weather?: Weather;
   isRejected: boolean;
+  isLoading: boolean;
 };
 
 export type ContainerProps = {

--- a/src/hooks/useFetch.ts
+++ b/src/hooks/useFetch.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+const useFetch = <T extends object>(url: RequestInfo | URL) => {
+  const [data, setData] = useState<T>();
+  const [loading, setLoading] = useState(true);
+
+  const fetchData = async (url: RequestInfo | URL) => {
+    const response = await fetch(url);
+    const data = (await response.json()) as T;
+
+    setLoading(false);
+    setData(data);
+  };
+
+  const reFetchData = (url: RequestInfo | URL) => {
+    fetchData(url);
+  };
+
+  useEffect(() => {
+    fetchData(url);
+  }, []);
+
+  return { data, loading, reFetchData };
+};
+
+export default useFetch;

--- a/src/hooks/useLunchMenu.ts
+++ b/src/hooks/useLunchMenu.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+
+import { SuccessLunchMenuRoot, FailLunchMenuRoot } from '@Types/lunchMenu';
+
+import useFetch from './useFetch';
+
+const LUNCH_MENU_OPEN_NEIS_URL =
+  'https://open.neis.go.kr/hub/mealServiceDietInfo?KEY=954dac30b088454d9a95700f044ce620&Type=json&pIndex=1&pSize=100&';
+
+type SchoolInfoType = {
+  areaCode: string;
+  schoolCode: string;
+  date: number;
+};
+
+const useLunchMenu = (schoolInfo: SchoolInfoType) => {
+  const [menu, setMenu] = useState<string[] | undefined>();
+  const [error, setError] = useState<string | undefined>();
+
+  const { data, loading, reFetchData } = useFetch<
+    SuccessLunchMenuRoot | FailLunchMenuRoot
+  >(
+    LUNCH_MENU_OPEN_NEIS_URL +
+      `ATPT_OFCDC_SC_CODE=${schoolInfo.areaCode}&SD_SCHUL_CODE=${schoolInfo.schoolCode}&MLSV_YMD=${schoolInfo.date}`,
+  );
+
+  const updateSchoolInfo = (updateSchoolInfo: Partial<SchoolInfoType>) => {
+    const newSchoolInfo = { ...schoolInfo, ...updateSchoolInfo };
+
+    reFetchData(
+      LUNCH_MENU_OPEN_NEIS_URL +
+        `ATPT_OFCDC_SC_CODE=${newSchoolInfo.areaCode}&SD_SCHUL_CODE=${newSchoolInfo.schoolCode}&MLSV_YMD=${newSchoolInfo.date}`,
+    );
+  };
+
+  const progressSetMenu = () => {
+    if (!data) return;
+
+    if ('RESULT' in data) {
+      setError('등록된 정보가 없습니다.');
+
+      return;
+    }
+
+    const { DDISH_NM } = data.mealServiceDietInfo[1].row[0];
+
+    setMenu(
+      DDISH_NM.split('<br/>').map((item: string) => {
+        return item.replace(/[0-9.()\s]/g, '');
+      }),
+    );
+  };
+
+  useEffect(() => {
+    progressSetMenu();
+  }, [data]);
+
+  return { loading, menu, error, updateSchoolInfo };
+};
+
+export default useLunchMenu;

--- a/src/styles/darkTheme.ts
+++ b/src/styles/darkTheme.ts
@@ -1,6 +1,7 @@
 import theme from './theme';
 
-const darkTheme = Object.assign(theme, {
+const darkTheme = {
+  ...theme,
   text: theme.color.neutral[100],
   subText: theme.color.neutral[400],
   background: {
@@ -20,6 +21,6 @@ const darkTheme = Object.assign(theme, {
     error: theme.color.error[700],
     white: theme.color.white,
   },
-});
+};
 
 export default darkTheme;

--- a/src/styles/lightTheme.ts
+++ b/src/styles/lightTheme.ts
@@ -1,6 +1,7 @@
 import theme from './theme';
 
-const lightTheme = Object.assign(theme, {
+const lightTheme = {
+  ...theme,
   text: theme.color.neutral[800],
   subText: theme.color.neutral[400],
   background: {
@@ -20,6 +21,6 @@ const lightTheme = Object.assign(theme, {
     error: theme.color.error[400],
     white: theme.color.white,
   },
-});
+};
 
 export default lightTheme;

--- a/src/types/lunchMenu.ts
+++ b/src/types/lunchMenu.ts
@@ -1,0 +1,42 @@
+export type SuccessLunchMenuRoot = {
+  mealServiceDietInfo: MealServiceDietInfo[];
+};
+
+export type FailLunchMenuRoot = {
+  RESULT: {
+    CODE: string;
+    MESSAGE: string;
+  };
+};
+
+export type MealServiceDietInfo = {
+  head: Head[];
+  row: Row[];
+};
+
+export type Head = {
+  list_total_count?: number;
+  RESULT?: Result;
+};
+
+export type Result = {
+  CODE: string;
+  MESSAGE: string;
+};
+
+export type Row = {
+  ATPT_OFCDC_SC_CODE: string;
+  ATPT_OFCDC_SC_NM: string;
+  SD_SCHUL_CODE: string;
+  SCHUL_NM: string;
+  MMEAL_SC_CODE: string;
+  MMEAL_SC_NM: string;
+  MLSV_YMD: string;
+  MLSV_FGR: string;
+  DDISH_NM: string;
+  ORPLC_INFO: string;
+  CAL_INFO: string;
+  NTR_INFO: string;
+  MLSV_FROM_YMD: string;
+  MLSV_TO_YMD: string;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
       "@Hooks/*": ["./src/hooks/*"],
       "@Pages/*": ["./src/pages/*"],
       "@Utils/*": ["./src/utils/*"],
-      "@Styles/*": ["./src/styles/*"]
+      "@Styles/*": ["./src/styles/*"],
+      "@Types/*": ["./src/types/*"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
- [x] 점심 메뉴 API를 다루는 훅 만들기 - useLunchMenu
- [x] API 통신 훅 만들기 - useFetch
- [x] 스토리북 폴더 분리
- [x] SummaryList, WeatherBdage 컴포넌트 분리

---

## useLunchMenu 참고사항

- API 호출을 위해 학교지역코드, 학교코드, 날짜를 인자로 받아야 함
- menu엔 단순히 메뉴만 들어가있는 배열 -> 이후에 알레르기, 원산지까지 필요할 경우가 있을 텐데, 다른 변수에 저장하여 return 해야 함.
- updateSchoolInfo() 함수를 호출하면 새로운 menu가 return 되어 컴포넌트가 재랜더링됨. 인자는 학교지역코드, 학교코드, 날짜(모두 필수는 아님, 업데이트하고 싶은 것만)

---

## useFetch 참고 사항

- 현재는 GET 요청만 가능. 이후에 고도화 필요
- 전역 상태 관리 라이브러리 사용시 다른 fetch 또는 axios 사용해야 함
   - React.Suspense 사용도 고려해야 함

---

## 그외 

- 스토리북에서 라이트모드 안되었던 문제 해결
- Pages 절대 경로 수정(eslint)
- Weather과 관련된 API는 백엔드에서 처리 후 보내 주기로 함 🥳🥳🥳🥳