### PR TITLE
[FE] 모달 컴포넌트 구현 

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,13 +4,16 @@ import { RouterProvider } from 'react-router-dom';
 
 import router from './Router';
 import { worker } from './mocks/worker';
+import ModalProvider from './providers/ModalProvider';
 
-// if (process.env.NODE_ENV === 'development') {
-// }
-worker.start();
+if (process.env.NODE_ENV === 'development') {
+  worker.start();
+}
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <RouterProvider router={router}></RouterProvider>
+    <ModalProvider>
+      <RouterProvider router={router}></RouterProvider>
+    </ModalProvider>
   </React.StrictMode>,
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,6 @@ import { RouterProvider } from 'react-router-dom';
 
 import router from './Router';
 import { worker } from './mocks/worker';
-import ModalProvider from './providers/ModalProvider';
 
 if (process.env.NODE_ENV === 'development') {
   worker.start();
@@ -12,8 +11,6 @@ if (process.env.NODE_ENV === 'development') {
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <ModalProvider>
-      <RouterProvider router={router}></RouterProvider>
-    </ModalProvider>
+    <RouterProvider router={router}></RouterProvider>
   </React.StrictMode>,
 );

--- a/src/mocks/userHandlers.ts
+++ b/src/mocks/userHandlers.ts
@@ -5,8 +5,8 @@ const userResponse = {
   data: {
     userId: 'string',
     nickName: 'KHD',
-    schoolName: '서원주초등학교',
-    // schoolName: undefined,
+    // schoolName: '서원주초등학교',
+    schoolName: undefined,
     schoolCode: 'string',
     areaCode: 'string',
   },

--- a/src/pages/App/Header/style.ts
+++ b/src/pages/App/Header/style.ts
@@ -10,6 +10,7 @@ export const Layout = styled.div`
   grid-template-columns: repeat(12, 1fr);
 
   background-color: ${(props) => props.theme.background.gray};
+  border-bottom: 1px solid ${(props) => props.theme.primaryText};
 
   z-index: 1;
 `;

--- a/src/pages/App/SideNavLink/style.ts
+++ b/src/pages/App/SideNavLink/style.ts
@@ -7,7 +7,10 @@ export const Layout = styled.div`
 
   ${flexCustom('column', 'stretch', 'flex-start')}
 
+  background-color: ${(props) => props.theme.background.gray};
+
   min-width: 25rem;
   padding: 10rem 3rem 3rem;
-  box-shadow: rgba(99, 99, 99, 0.2) 0px 2px 4px 0px;
+
+  border-right: 1px solid ${(props) => props.theme.primaryText};
 `;

--- a/src/pages/App/index.tsx
+++ b/src/pages/App/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { PiSunBold, PiMoonStarsBold } from 'react-icons/pi';
 import { Outlet, useLocation } from 'react-router-dom';
+import ModalProvider from 'src/providers/ModalProvider';
 import { ThemeProvider } from 'styled-components';
 
 import route from '@Utils/route';
@@ -38,18 +39,20 @@ function App() {
     <>
       <GlobalStyle />
       <ThemeProvider theme={isLightTheme ? lightTheme : darkTheme}>
-        <Header pathname={pathname} />
-        <S.DefaultPageLayout>
-          {pathname !== route.calculatePath([ROUTE_PATH.main]) && (
-            <SideNavLink pathname={pathname} />
-          )}
-          <S.PageWrapper>
-            <Outlet />
-          </S.PageWrapper>
-          <S.ThemeToggleButton handleClick={toggleTheme}>
-            {isLightTheme ? <PiSunBold /> : <PiMoonStarsBold />}
-          </S.ThemeToggleButton>
-        </S.DefaultPageLayout>
+        <ModalProvider>
+          <Header pathname={pathname} />
+          <S.DefaultPageLayout>
+            {pathname !== route.calculatePath([ROUTE_PATH.main]) && (
+              <SideNavLink pathname={pathname} />
+            )}
+            <S.PageWrapper>
+              <Outlet />
+            </S.PageWrapper>
+            <S.ThemeToggleButton handleClick={toggleTheme}>
+              {isLightTheme ? <PiSunBold /> : <PiMoonStarsBold />}
+            </S.ThemeToggleButton>
+          </S.DefaultPageLayout>
+        </ModalProvider>
       </ThemeProvider>
     </>
   );

--- a/src/pages/ClassManagement/LunchMenu/RegisterSchoolButton/index.tsx
+++ b/src/pages/ClassManagement/LunchMenu/RegisterSchoolButton/index.tsx
@@ -1,85 +1,21 @@
-import { MouseEvent, useState } from 'react';
-import styled from 'styled-components';
+import { useModal } from 'src/providers/ModalProvider';
 
 import Button from '@Components/Button';
-import Input from '@Components/Input';
+
+import RegisterSchoolModal from '../RegisterSchoolModal';
 
 function RegisterSchoolButton() {
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const onClickBackdrop = () => {
-    setIsModalOpen(false);
+  const { openModal } = useModal();
+  const handleClickButton = () => {
+    openModal(<RegisterSchoolModal />);
   };
-
-  const preventCloseModal = (event: MouseEvent) => {
-    event.stopPropagation();
-  };
-
   return (
     <>
-      <Button fontSize="2rem" handleClick={() => setIsModalOpen(true)}>
+      <Button fontSize="2rem" handleClick={handleClickButton}>
         학교 등록하기
       </Button>
-      {isModalOpen && (
-        <ModalLayout onClick={onClickBackdrop}>
-          <div onClick={preventCloseModal}>
-            {/* 이 곳에 children이 온다. */}
-            <SearchSchoolLayout>
-              <SearchSchoolForm>
-                <Input size="sm" placeholder="학교명을 검색하세요." />
-                <Button type="submit">검색</Button>
-              </SearchSchoolForm>
-              <SearchResult>
-                <div>
-                  돋보기로 무언가를 찾고있는 티처캔 캐릭터를 svg로 만들어 주세요
-                  :)
-                </div>
-              </SearchResult>
-            </SearchSchoolLayout>
-          </div>
-        </ModalLayout>
-      )}
     </>
   );
 }
 
 export default RegisterSchoolButton;
-
-const ModalLayout = styled.div`
-  position: fixed;
-  min-width: 100vw;
-  min-height: 100vh;
-  top: 0;
-  left: 0;
-
-  display: grid;
-  align-items: center;
-  justify-items: center;
-
-  background-color: ${(props) => props.theme.modalBackground};
-
-  z-index: 5;
-`;
-
-const SearchSchoolLayout = styled.div`
-  display: grid;
-  row-gap: 20px;
-
-  min-width: 360px;
-  max-width: 360px;
-
-  padding: 20px;
-  border-radius: 8px;
-
-  background-color: ${(props) => props.theme.background.gray};
-`;
-
-const SearchSchoolForm = styled.form`
-  display: grid;
-  grid-template-columns: 1fr auto;
-`;
-
-const SearchResult = styled.div`
-  min-height: 240px;
-  overflow: auto;
-`;

--- a/src/pages/ClassManagement/LunchMenu/RegisterSchoolModal/index.tsx
+++ b/src/pages/ClassManagement/LunchMenu/RegisterSchoolModal/index.tsx
@@ -1,0 +1,22 @@
+import Button from '@Components/Button';
+import Input from '@Components/Input';
+
+import * as S from './style';
+
+function RegisterSchoolModal() {
+  return (
+    <S.SearchSchoolLayout>
+      <S.SearchSchoolForm>
+        <Input size="sm" placeholder="학교명을 검색하세요." />
+        <Button type="submit">검색</Button>
+      </S.SearchSchoolForm>
+      <S.SearchResult>
+        <div>
+          돋보기로 무언가를 찾고있는 티처캔 캐릭터를 svg로 만들어 주세요 :)
+        </div>
+      </S.SearchResult>
+    </S.SearchSchoolLayout>
+  );
+}
+
+export default RegisterSchoolModal;

--- a/src/pages/ClassManagement/LunchMenu/RegisterSchoolModal/style.ts
+++ b/src/pages/ClassManagement/LunchMenu/RegisterSchoolModal/style.ts
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const SearchSchoolLayout = styled.div`
+  display: grid;
+  row-gap: 20px;
+`;
+
+export const SearchSchoolForm = styled.form`
+  display: flex;
+  gap: 10px;
+
+  input {
+    max-width: 100%;
+  }
+`;
+
+export const SearchResult = styled.div`
+  min-height: 300px;
+  overflow: auto;
+`;

--- a/src/providers/ModalProvider/index.tsx
+++ b/src/providers/ModalProvider/index.tsx
@@ -1,10 +1,12 @@
 import {
+  MouseEventHandler,
   PropsWithChildren,
   ReactNode,
   createContext,
   useContext,
   useState,
 } from 'react';
+import styled from 'styled-components';
 
 type ModalContext = {
   openModal: (model: ReactNode) => void;
@@ -29,13 +31,14 @@ const ModalProvider = ({ children }: PropsWithChildren) => {
   return (
     <ModalContext.Provider value={value}>
       {children}
-      {isOpen && currentModal}
+      {isOpen && <Modal closeModal={closeModal}>{currentModal}</Modal>}
     </ModalContext.Provider>
   );
 };
 
 export default ModalProvider;
 
+// 전역에서 모달을 열고 닫을 수 있는 custom Hook
 export const useModal = () => {
   const value = useContext(ModalContext);
 
@@ -45,3 +48,49 @@ export const useModal = () => {
 
   return value;
 };
+
+type ModalProps = {
+  closeModal: () => void;
+};
+
+const Modal = ({ children, closeModal }: PropsWithChildren<ModalProps>) => {
+  const onClickBackdrop = () => {
+    closeModal();
+  };
+
+  const preventCloseModal: MouseEventHandler = (event) => {
+    event.stopPropagation();
+  };
+
+  return (
+    <ModalLayout onClick={onClickBackdrop}>
+      <ModalContainer onClick={preventCloseModal}>{children}</ModalContainer>
+    </ModalLayout>
+  );
+};
+
+const ModalLayout = styled.div`
+  position: fixed;
+  min-width: 100vw;
+  min-height: 100vh;
+  top: 0;
+  left: 0;
+
+  display: grid;
+  align-items: center;
+  justify-items: center;
+
+  background-color: ${(props) => props.theme.modalBackground};
+
+  z-index: 5;
+`;
+
+const ModalContainer = styled.div`
+  width: 480px;
+  max-height: 500px;
+
+  padding: 20px;
+  border-radius: 8px;
+
+  background-color: ${(props) => props.theme.background.gray};
+`;

--- a/src/providers/ModalProvider/index.tsx
+++ b/src/providers/ModalProvider/index.tsx
@@ -1,0 +1,47 @@
+import {
+  PropsWithChildren,
+  ReactNode,
+  createContext,
+  useContext,
+  useState,
+} from 'react';
+
+type ModalContext = {
+  openModal: (model: ReactNode) => void;
+  closeModal: () => void;
+} | null;
+
+const ModalContext = createContext<ModalContext>(null);
+
+const ModalProvider = ({ children }: PropsWithChildren) => {
+  const [currentModal, setCurrentModal] = useState<ReactNode | null>(null);
+  const isOpen = !!currentModal;
+
+  const openModal = (modal: ReactNode) => setCurrentModal(modal);
+
+  const closeModal = () => setCurrentModal(null);
+
+  const value = {
+    openModal,
+    closeModal,
+  };
+
+  return (
+    <ModalContext.Provider value={value}>
+      {children}
+      {isOpen && currentModal}
+    </ModalContext.Provider>
+  );
+};
+
+export default ModalProvider;
+
+export const useModal = () => {
+  const value = useContext(ModalContext);
+
+  if (value === null) {
+    throw new Error('Modal 에러');
+  }
+
+  return value;
+};


### PR DESCRIPTION
## 모달 컴포넌트 구현

### 1. Provider

```tsx
type ModalContext = {
  openModal: (model: ReactNode) => void;
  closeModal: () => void;
} | null;

// 모달 컨텍스트를 생성합니다.
const ModalContext = createContext<ModalContext>(null);

// 모달 Provider를 생성하여 pages/App.tsx 에서 이를 사용합니다.
const ModalProvider = ({ children }: PropsWithChildren) => {
  const [currentModal, setCurrentModal] = useState<ReactNode | null>(null);
  const isOpen = !!currentModal;

  // 모달을 엽니다.
  const openModal = (modal: ReactNode) => setCurrentModal(modal);

 // 모달을 닫습니다.
  const closeModal = () => setCurrentModal(null);

  const value = {
    openModal,
    closeModal,
  };

  return (
    <ModalContext.Provider value={value}>
      {children}
      {isOpen && <Modal closeModal={closeModal}>{currentModal}</Modal>}
    </ModalContext.Provider>
  );
};
```

### 2. useModal

// 전역에서 모달을 열고 닫을 수 있는 custom Hook
export const useModal = () => {
  const value = useContext(ModalContext);

  if (value === null) {
    throw new Error('Modal 에러');
  }

  return value;
};

type ModalProps = {
  closeModal: () => void;
};

이를 다음과 같이 사용할 수 있습니다.

```tsx
function Profile() {
  const { openModal } = useModal()

  const handleClickModalButton () => openModal(<div>모달입니다.</div>)
}
```

### 3. 공유 내용

`src/providers/ModalProvider/index.tsx` 에 type, context, provider, hook, component, style이 모두 같이 있습니다. 일단 하나의 관심사이기 때문에 따로 파일을 분리하지 않았습니다.

## 사이드 내비게이션 디자인 변경 제안

### 이전 디자인
![스크린샷 2023-08-12 오후 2 08 59](https://github.com/choco-team/FE_TeacherCan/assets/57981252/6c114749-4c43-4cf6-9d55-8bad454caeda)

### 변경 디자인
![스크린샷 2023-08-12 오후 2 14 50](https://github.com/choco-team/FE_TeacherCan/assets/57981252/1486f7f8-bcb8-43ca-a720-0ea22f036a92)
