### PR TITLE
[FE] 회원가입 비밀번호 유효성 검사 수정 및 로그인 response 구조 변경

### DIFF
--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -17,8 +17,11 @@ export type SignInRequest = Omit<AuthRequest, 'nickname'>;
 export type ValidationEmailRequest = Omit<AuthRequest, 'nickname' | 'password'>;
 
 export type SignInResponse = {
+  code: number;
   result: boolean;
-  token: string;
+  data: {
+    token: string;
+  };
 };
 
 // request 접두사 제거

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,5 +10,7 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <RouterProvider router={router}></RouterProvider>,
+  <React.StrictMode>
+    <RouterProvider router={router}></RouterProvider>
+  </React.StrictMode>,
 );

--- a/src/pages/Auth/SignIn/index.tsx
+++ b/src/pages/Auth/SignIn/index.tsx
@@ -39,8 +39,8 @@ function SignIn() {
   const navigate = useNavigate();
 
   const { isLoading, signIn } = useSignIn({
-    onSuccess: ({ token }) => {
-      sessionStorage.setItem('token', token);
+    onSuccess: ({ data }) => {
+      sessionStorage.setItem('token', data.token);
       navigate(route.calculatePath([ROUTE_PATH.main]));
     },
   });

--- a/src/pages/Auth/SignUp/index.tsx
+++ b/src/pages/Auth/SignUp/index.tsx
@@ -32,7 +32,7 @@ const SIGN_UP_INPUTS = [
     label: '비밀번호',
     placeholder: '영어, 숫자, 특수문자 포함 8자 이상',
     autocomplete: 'new-password',
-    validationMessage: '영어, 숫자, 특수문자 포함 8~20자로 입력해주세요.',
+    validationMessage: '영어, 숫자, 특수문자 포함 8자 이상 입력해주세요.',
   },
   {
     name: 'passwordConfirmation',
@@ -56,9 +56,9 @@ const validate = (inputValue: Record<string, string>) => {
   const regExp = {
     // 아이디: 영어 1글자 포함 영어/숫자 6~15자
     email: /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/,
-    // 비밀번호: 영어 대소문자+숫자+특수문자 8~20자
+    // 비밀번호: 영어 대소문자+숫자+특수문자 8자 이상
     password:
-      /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*#?&])[a-zA-Z\d@$!%*#?&]{8,20}$/,
+      /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[\[\]\{\}\/\(\)\.\?\<\>!@#$%^&*])[a-zA-Z\d\[\]\{\}\/\(\)\.\?\<\>!@#$%^&*]{8,}$/,
     // 닉네임: 한글/영어/숫자 2~10자
     nickname: /^[가-힣a-zA-Z0-9]{2,10}$/,
   } as const;


### PR DESCRIPTION
close #129 

### 회원가입 비밀번호 유효성 검사 수정
- 비밀번호 8~20자 제한에서 8자 이상 제한으로 변경 (max값이 너무 낮아서 우선 삭제)
- 정규표현식 특수기호 빠진 부분 추가

### 로그인 `response` 구조 변경
- 백엔드 `response` 구조 변경에 따라 로그인 시 `token`을 저장하기 위한 `response` 구조 변경