### PR TITLE
[FE] 학생 정보(명렬표) 조회 페이지 마크업

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -9,6 +9,7 @@ import SignUp from '@Pages/Auth/SignUp';
 import LunchMenu from '@Pages/ClassManagement/LunchMenu';
 import Home from '@Pages/Home';
 import StudentManagement from '@Pages/StudentManagement';
+import StudentInfo from '@Pages/StudentManagement/StudentInfo';
 import StudentRegister from '@Pages/StudentManagement/StudentRegister';
 import RandomPick from '@Pages/Tools/RandomPick';
 
@@ -74,6 +75,7 @@ const router = createBrowserRouter([
         children: [
           {
             path: ROUTE_PATH.studentInfo,
+            element: <StudentInfo />,
           },
           {
             path: ROUTE_PATH.studentRegister,

--- a/src/components/AgGrid/index.tsx
+++ b/src/components/AgGrid/index.tsx
@@ -8,7 +8,7 @@ import 'ag-grid-community/styles/ag-grid.css'; // Core grid CSS, always needed
 import 'ag-grid-community/styles/ag-theme-alpine.css'; // Optional theme CSS
 
 const AgGrid = (
-  { gridOptions, rowData, fullHeight, minHeight }: T.AgGrid,
+  { gridOptions, rowData, fullHeight, minHeight, ...props }: T.AgGrid,
   ref: ForwardedRef<AgGridReact>,
 ) => {
   return (
@@ -17,7 +17,16 @@ const AgGrid = (
       fullHeight={fullHeight}
       minHeight={minHeight}
     >
-      <AgGridReact ref={ref} gridOptions={gridOptions} rowData={rowData} />
+      <AgGridReact
+        ref={ref}
+        gridOptions={{
+          suppressDragLeaveHidesColumns: true,
+          animateRows: true,
+          ...gridOptions,
+        }}
+        rowData={rowData}
+        {...props}
+      />
     </S.AgGridWrapper>
   );
 };

--- a/src/components/AgGrid/style.ts
+++ b/src/components/AgGrid/style.ts
@@ -9,6 +9,7 @@ export const AgGridWrapper = styled.div<{
   width: 100%;
   height: ${({ fullHeight }) => (fullHeight ? '100%' : undefined)};
   min-height: ${({ minHeight }) => `${minHeight}px`};
+  font-family: inherit;
 
   --ag-row-hover-color: ${({ theme }) =>
     `${theme.selectionBackground.primary}${getHexOpacity(0.5)}`};

--- a/src/components/Button/style.ts
+++ b/src/components/Button/style.ts
@@ -28,7 +28,9 @@ export const Button = styled.button<StyledButton>`
   text-align: center;
   font-size: ${(props) => props.fontSize};
   font-weight: ${(props) => props.fontWeight};
-  transition: background-color 0.3s ease, border-color 0.3s ease;
+  transition:
+    background-color 0.3s ease,
+    border-color 0.3s ease;
 
   ${({ size }) =>
     (size === 'sm' &&
@@ -49,31 +51,27 @@ export const Button = styled.button<StyledButton>`
     `)}
 
   &:hover {
-    background-color: ${(props) =>
-      (props.concept === 'contained' &&
-        props.theme.hoverBackground[props.variant]) ||
-      (props.concept === 'outlined' &&
-        `${props.theme.color.gray[500]}${getHexOpacity(0.05)}`)};
-    border-color: ${(props) =>
-      props.concept === 'outlined' &&
-      props.theme.hoverBackground[props.variant]};
-    color: ${(props) =>
-      props.concept === 'outlined' &&
-      props.theme.hoverBackground[props.variant]};
+    background-color: ${({ theme, concept, variant }) =>
+      (concept === 'contained' && theme.hoverBackground[variant]) ||
+      ((concept === 'outlined' || concept === 'text') &&
+        `${theme.color.gray[500]}${getHexOpacity(0.05)}`)};
+    border-color: ${({ theme, concept, variant }) =>
+      concept === 'outlined' && theme.hoverBackground[variant]};
+    color: ${({ theme, concept, variant }) =>
+      (concept === 'outlined' || concept === 'text') &&
+      theme.hoverBackground[variant]};
   }
 
   &:active {
-    background-color: ${(props) =>
-      (props.concept === 'contained' &&
-        props.theme.activeBackground[props.variant]) ||
-      (props.concept === 'outlined' &&
-        `${props.theme.color.gray[500]}${getHexOpacity(0.1)}`)};
-    border-color: ${(props) =>
-      props.concept === 'outlined' &&
-      props.theme.activeBackground[props.variant]};
-    color: ${(props) =>
-      props.concept === 'outlined' &&
-      props.theme.activeBackground[props.variant]};
+    background-color: ${({ theme, concept, variant }) =>
+      (concept === 'contained' && theme.activeBackground[variant]) ||
+      ((concept === 'outlined' || concept === 'text') &&
+        `${theme.color.gray[500]}${getHexOpacity(0.1)}`)};
+    border-color: ${({ theme, concept, variant }) =>
+      concept === 'outlined' && theme.activeBackground[variant]};
+    color: ${({ theme, concept, variant }) =>
+      (concept === 'outlined' || concept === 'text') &&
+      theme.activeBackground[variant]};
   }
 
   &:disabled {

--- a/src/components/Button/type.ts
+++ b/src/components/Button/type.ts
@@ -13,10 +13,10 @@ type Button = {
   border?: string;
   borderRadius?: string;
   padding?: string;
-  handleClick?: () => void;
   color?: string;
   fontSize?: string;
   fontWeight?: string;
+  handleClick?: HTMLButtonElement['onclick'];
 } & ButtonHTMLAttributes<HTMLButtonElement>;
 
 type StyledButton = {

--- a/src/constant/studentManagement/studentInfo.ts
+++ b/src/constant/studentManagement/studentInfo.ts
@@ -1,0 +1,7 @@
+export const STUDENT_INFO_KEY_NAME = {
+  studentNumber: '번호',
+  studentName: '이름',
+  gender: '성별',
+  male: '남',
+  female: '여',
+} as const;

--- a/src/hooks/studentManagement/studentRegister/useExcelRegister.ts
+++ b/src/hooks/studentManagement/studentRegister/useExcelRegister.ts
@@ -1,6 +1,6 @@
+import { STUDENT_INFO_KEY_NAME } from '@Constant/studentManagement/studentInfo';
 import { read, utils, writeFile } from 'xlsx';
 
-import { STUDENT_INFO_KEY_NAME } from '@Pages/StudentManagement/StudentRegister/constant';
 import type { StudentBaseInfo } from '@Pages/StudentManagement/StudentRegister/type';
 
 const useExcelRegister = ({

--- a/src/pages/StudentManagement/StudentInfo/index.tsx
+++ b/src/pages/StudentManagement/StudentInfo/index.tsx
@@ -1,0 +1,113 @@
+import { STUDENT_INFO_KEY_NAME } from '@Constant/studentManagement/studentInfo';
+import { type ColDef, type GridOptions } from 'ag-grid-community';
+import type { AgGridReact } from 'ag-grid-react';
+import { MouseEvent, useRef, useState } from 'react';
+import { FaChevronDown, FaStar } from 'react-icons/fa6';
+
+import AgGrid from '@Components/AgGrid';
+
+import { MOCK_STUDENT_LISTS } from './mock';
+import * as S from './style';
+
+const defaultColumnDefs: ColDef[] = [
+  {
+    headerName: STUDENT_INFO_KEY_NAME.studentNumber,
+    field: 'studentNumber',
+    flex: 0.5,
+    cellStyle: { textAlign: 'center' },
+  },
+  {
+    headerName: STUDENT_INFO_KEY_NAME.studentName,
+    field: 'studentName',
+    minWidth: 180,
+    flex: 1,
+    cellStyle: { textAlign: 'center' },
+  },
+  {
+    headerName: STUDENT_INFO_KEY_NAME.gender,
+    field: 'gender',
+    flex: 0.5,
+    cellStyle: { textAlign: 'center' },
+  },
+];
+
+const StudentInfo = () => {
+  const studentListItems = MOCK_STUDENT_LISTS.sort(({ isMain }) =>
+    isMain ? -1 : 1,
+  );
+  const [selectedStudentList, setSelectedStudentList] = useState(
+    studentListItems[0],
+  );
+  const [isOpenAccordion, setIsOpenAccordion] = useState(false);
+
+  const gridRef = useRef<AgGridReact>(null);
+  const rowData = selectedStudentList.students.map(
+    ({ columns, ...studentInfo }) => ({
+      ...studentInfo,
+      ...Object.fromEntries(columns.map(({ field, value }) => [field, value])),
+    }),
+  );
+
+  const customColumnDefs: ColDef[] = selectedStudentList.columns.map(
+    ({ field }) => ({ field, headerName: field }),
+  );
+
+  const columnDefs: ColDef[] = [...defaultColumnDefs, ...customColumnDefs];
+
+  const gridOptions: GridOptions = {
+    defaultColDef: {
+      resizable: true,
+      minWidth: 70,
+    },
+  };
+
+  const handleClickStudentListItem = (event: MouseEvent<HTMLButtonElement>) => {
+    const { value: selectedId } = event.currentTarget;
+    const selectedItem = studentListItems.find(
+      ({ id }) => id === Number(selectedId),
+    );
+    if (selectedItem) setSelectedStudentList(selectedItem);
+  };
+
+  const handleToggleAccordion = () => {
+    setIsOpenAccordion((prev) => !prev);
+  };
+
+  return (
+    <S.Layout>
+      <S.AccordionContainer>
+        <S.StudentListTitleContainer $isOpenAccordion={isOpenAccordion}>
+          {studentListItems.map(({ id, name, isMain }) => (
+            <S.StudentListTitleButton
+              key={id}
+              size="sm"
+              concept="text"
+              $isSelected={selectedStudentList.id === id}
+              value={id}
+              onClick={handleClickStudentListItem}
+            >
+              {isMain && <FaStar />}
+              {name}
+            </S.StudentListTitleButton>
+          ))}
+        </S.StudentListTitleContainer>
+        <S.AccordionToggleButton
+          concept="text"
+          $isOpenAccordion={isOpenAccordion}
+          onClick={handleToggleAccordion}
+        >
+          <FaChevronDown />
+        </S.AccordionToggleButton>
+      </S.AccordionContainer>
+      <AgGrid
+        ref={gridRef}
+        gridOptions={gridOptions}
+        rowData={rowData}
+        columnDefs={columnDefs}
+        fullHeight
+      />
+    </S.Layout>
+  );
+};
+
+export default StudentInfo;

--- a/src/pages/StudentManagement/StudentInfo/mock.ts
+++ b/src/pages/StudentManagement/StudentInfo/mock.ts
@@ -1,0 +1,1058 @@
+export const MOCK_STUDENT_LISTS = [
+  {
+    id: 1,
+    name: '3월 6학년 1반 명렬표',
+    isMain: false,
+    createdAt: '2023-10-02T11:51:26.815Z',
+    updatedAt: '2023-10-02T11:51:26.815Z',
+    columns: [
+      { id: 1, field: '전화번호' },
+      { id: 2, field: '주소' },
+    ],
+    students: [
+      {
+        id: 1,
+        studentNumber: 1,
+        studentName: '홍길동',
+        gender: '남',
+        allergy: [1, 2, 6],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 2,
+        studentNumber: 2,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [2, 3],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 3,
+        studentNumber: 3,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 4,
+        studentNumber: 4,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 5,
+        studentNumber: 5,
+        studentName: '강학생',
+        gender: '남',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 6,
+        studentNumber: 6,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 7,
+        studentNumber: 7,
+        studentName: '최학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 8,
+        studentNumber: 8,
+        studentName: '김학생',
+        gender: '남',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 9,
+        studentNumber: 9,
+        studentName: '김학생',
+        gender: '남',
+        allergy: [6],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 10,
+        studentNumber: 10,
+        studentName: '정학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 11,
+        studentNumber: 11,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [2, 11],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 12,
+        studentNumber: 12,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [11],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 13,
+        studentNumber: 13,
+        studentName: '김학생',
+        gender: '남',
+        allergy: [5],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 14,
+        studentNumber: 14,
+        studentName: '김학생',
+        gender: '남',
+        allergy: [1],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 15,
+        studentNumber: 15,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 16,
+        studentNumber: 16,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 17,
+        studentNumber: 17,
+        studentName: '이학생',
+        gender: '남',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 2,
+    name: '4월 6학년 1반 명렬표',
+    isMain: true,
+    createdAt: '2023-10-02T11:51:26.815Z',
+    updatedAt: '2023-10-02T11:51:26.815Z',
+    columns: [
+      { id: 1, field: '전화번호' },
+      { id: 2, field: '주소' },
+    ],
+    students: [
+      {
+        id: 1,
+        studentNumber: 1,
+        studentName: '티처캔',
+        gender: '남',
+        allergy: [1, 2, 6],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 2,
+        studentNumber: 2,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [2, 3],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 3,
+        studentNumber: 3,
+        studentName: '이학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 4,
+        studentNumber: 4,
+        studentName: '전학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 5,
+        studentNumber: 5,
+        studentName: '강학생',
+        gender: '남',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 6,
+        studentNumber: 6,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 7,
+        studentNumber: 7,
+        studentName: '최학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 8,
+        studentNumber: 8,
+        studentName: '김학생',
+        gender: '남',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 9,
+        studentNumber: 9,
+        studentName: '김학생',
+        gender: '남',
+        allergy: [6],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 10,
+        studentNumber: 10,
+        studentName: '정학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 11,
+        studentNumber: 11,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [2, 11],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 12,
+        studentNumber: 12,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [11],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 13,
+        studentNumber: 13,
+        studentName: '김학생',
+        gender: '남',
+        allergy: [5],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 14,
+        studentNumber: 14,
+        studentName: '김학생',
+        gender: '남',
+        allergy: [1],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 15,
+        studentNumber: 15,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 16,
+        studentNumber: 16,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+      {
+        id: 17,
+        studentNumber: 17,
+        studentName: '이학생',
+        gender: '남',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '전화번호',
+            value: '010-1234-5678',
+          },
+          {
+            id: 2,
+            field: '주소',
+            value: '티처캔아파트 102동 304호',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 3,
+    name: '5월 6학년 1반 명렬표',
+    isMain: true,
+    createdAt: '2023-10-02T11:51:26.815Z',
+    updatedAt: '2023-10-02T11:51:26.815Z',
+    columns: [
+      { id: 1, field: '점수' },
+      { id: 2, field: '평가' },
+    ],
+    students: [
+      {
+        id: 1,
+        studentNumber: 1,
+        studentName: '티처캔',
+        gender: '남',
+        allergy: [1, 2, 6],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '100',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '잘함',
+          },
+        ],
+      },
+      {
+        id: 2,
+        studentNumber: 2,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [2, 3],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '85',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '보통',
+          },
+        ],
+      },
+      {
+        id: 3,
+        studentNumber: 3,
+        studentName: '이학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '70',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '노력요함',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 4,
+    name: '6월 6학년 1반 명렬표',
+    isMain: false,
+    createdAt: '2023-10-02T11:51:26.815Z',
+    updatedAt: '2023-10-02T11:51:26.815Z',
+    columns: [
+      { id: 1, field: '점수' },
+      { id: 2, field: '평가' },
+    ],
+    students: [
+      {
+        id: 1,
+        studentNumber: 1,
+        studentName: '전학생',
+        gender: '남',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '100',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '잘함',
+          },
+        ],
+      },
+      {
+        id: 2,
+        studentNumber: 2,
+        studentName: '티처캔',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '85',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '보통',
+          },
+        ],
+      },
+      {
+        id: 3,
+        studentNumber: 3,
+        studentName: '이학생',
+        gender: '남',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '70',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '노력요함',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 5,
+    name: '7월 6학년 1반 명렬표',
+    isMain: false,
+    createdAt: '2023-10-02T11:51:26.815Z',
+    updatedAt: '2023-10-02T11:51:26.815Z',
+    columns: [
+      { id: 1, field: '점수' },
+      { id: 2, field: '평가' },
+    ],
+    students: [
+      {
+        id: 1,
+        studentNumber: 1,
+        studentName: '티처캔',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '100',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '잘함',
+          },
+        ],
+      },
+      {
+        id: 2,
+        studentNumber: 2,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '85',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '보통',
+          },
+        ],
+      },
+      {
+        id: 3,
+        studentNumber: 3,
+        studentName: '이학생',
+        gender: '남',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '70',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '노력요함',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 6,
+    name: '8월 6학년 1반 명렬표',
+    isMain: false,
+    createdAt: '2023-10-02T11:51:26.815Z',
+    updatedAt: '2023-10-02T11:51:26.815Z',
+    columns: [],
+    students: [
+      {
+        id: 1,
+        studentNumber: 1,
+        studentName: '티처캔',
+        gender: '남',
+        allergy: [],
+        columns: [],
+      },
+      {
+        id: 2,
+        studentNumber: 2,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [],
+        columns: [],
+      },
+      {
+        id: 3,
+        studentNumber: 3,
+        studentName: '이학생',
+        gender: '여',
+        allergy: [],
+        columns: [],
+      },
+    ],
+  },
+  {
+    id: 7,
+    name: '9월 6학년 1반 명렬표',
+    isMain: false,
+    createdAt: '2023-10-02T11:51:26.815Z',
+    updatedAt: '2023-10-02T11:51:26.815Z',
+    columns: [
+      { id: 1, field: '점수' },
+      { id: 2, field: '평가' },
+    ],
+    students: [
+      {
+        id: 1,
+        studentNumber: 1,
+        studentName: '티처캔',
+        gender: '남',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '100',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '잘함',
+          },
+        ],
+      },
+      {
+        id: 2,
+        studentNumber: 2,
+        studentName: '김학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '85',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '보통',
+          },
+        ],
+      },
+      {
+        id: 3,
+        studentNumber: 3,
+        studentName: '이학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '70',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '노력요함',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 8,
+    name: '10월 6학년 1반 명렬표',
+    isMain: false,
+    createdAt: '2023-10-02T11:51:26.815Z',
+    updatedAt: '2023-10-02T11:51:26.815Z',
+    columns: [
+      { id: 1, field: '점수' },
+      { id: 2, field: '평가' },
+    ],
+    students: [
+      {
+        id: 1,
+        studentNumber: 1,
+        studentName: '티처캔',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '95',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '잘함',
+          },
+        ],
+      },
+      {
+        id: 2,
+        studentNumber: 2,
+        studentName: '한소희',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '80',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '보통',
+          },
+        ],
+      },
+      {
+        id: 3,
+        studentNumber: 3,
+        studentName: '이학생',
+        gender: '여',
+        allergy: [],
+        columns: [
+          {
+            id: 1,
+            field: '점수',
+            value: '70',
+          },
+          {
+            id: 2,
+            field: '평가',
+            value: '노력요함',
+          },
+        ],
+      },
+    ],
+  },
+];

--- a/src/pages/StudentManagement/StudentInfo/style.ts
+++ b/src/pages/StudentManagement/StudentInfo/style.ts
@@ -1,0 +1,80 @@
+import { type CSSProperties } from 'react';
+import styled from 'styled-components';
+
+import Button from '@Components/Button';
+
+import { flexCustom } from '@Styles/common';
+
+export const Layout = styled.div`
+  ${flexCustom('column', 'initial', 'initial')}
+  height: 100%;
+`;
+
+export const ColumnContainer = styled.div<{
+  gap?: CSSProperties['gap'];
+  flex?: CSSProperties['flex'];
+  height?: CSSProperties['height'];
+}>`
+  ${flexCustom('column', 'flex-start', 'flex-start')}
+  gap: ${({ gap = '16px' }) => gap};
+  flex: ${({ flex }) => flex};
+  width: 100%;
+  height: ${({ height }) => height};
+`;
+
+export const AccordionContainer = styled.div`
+  ${flexCustom('row', 'flex-start', 'flex-start', '0.5rem')}
+  margin-bottom: 0.5rem;
+`;
+
+export const AccordionToggleButton = styled(Button)<{
+  $isOpenAccordion: boolean;
+}>`
+  ${flexCustom('row', 'center', 'center')}
+  width: 2.4rem;
+  min-width: 2.4rem;
+  height: 2.4rem;
+  padding: 0;
+  border-radius: 50%;
+  transform: ${({ $isOpenAccordion }) => $isOpenAccordion && 'rotate(-180deg)'};
+
+  -webkit-transition: transform 0.3s ease;
+  transition: transform 0.3s ease;
+`;
+
+export const StudentListTitleContainer = styled.div<{
+  $isOpenAccordion: boolean;
+}>`
+  --title-button-line-height: 1.8rem;
+
+  ${flexCustom('row', 'flex-start', 'flex-start', '1rem')}
+  row-gap: 0.5rem;
+  flex-wrap: wrap;
+  height: ${({ $isOpenAccordion }) =>
+    $isOpenAccordion
+      ? 'auto'
+      : 'calc(var(--title-button-line-height) + 0.4rem * 2)'};
+`;
+
+export const StudentListTitleButton = styled(Button)<{
+  $isSelected: boolean;
+}>`
+  ${flexCustom('row', 'center', 'center', '0.25rem')}
+  border: none;
+  background-color: ${({ theme, $isSelected }) =>
+    $isSelected ? theme.selectionBackground.primary : 'transparent'};
+  color: ${({ theme, $isSelected }) =>
+    $isSelected ? theme.accentText : theme.subText};
+  font-weight: ${({ $isSelected }) => ($isSelected ? 600 : 400)};
+  line-height: var(--title-button-line-height);
+
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    background-color: ${({ theme }) => theme.selectionBackground.primary};
+  }
+
+  svg {
+    color: ${({ theme }) => theme.color.warning[400]};
+  }
+`;

--- a/src/pages/StudentManagement/StudentRegister/constant.ts
+++ b/src/pages/StudentManagement/StudentRegister/constant.ts
@@ -1,11 +1,3 @@
-export const STUDENT_INFO_KEY_NAME = {
-  studentNumber: '번호',
-  studentName: '이름',
-  gender: '성별',
-  male: '남',
-  female: '여',
-} as const;
-
 export const STUDENT_REGISTER_GUIDES = [
   '학생 명렬표 등록 방법에 대한 설명 설명 설명 설명 설명 설명입니다.',
   '학생 명렬표 등록 방법에 대한 설명 설명 설명 설명 설명 설명입니다.',

--- a/src/pages/StudentManagement/StudentRegister/index.tsx
+++ b/src/pages/StudentManagement/StudentRegister/index.tsx
@@ -1,3 +1,4 @@
+import { STUDENT_INFO_KEY_NAME } from '@Constant/studentManagement/studentInfo';
 import type { GridOptions } from 'ag-grid-community';
 import type { AgGridReact } from 'ag-grid-react';
 import { type ChangeEvent, type MouseEvent, useRef, useState } from 'react';
@@ -13,11 +14,7 @@ import Button from '@Components/Button';
 import Input from '@Components/Input';
 import TextArea from '@Components/TextArea';
 
-import {
-  CREATE_TYPE,
-  STUDENT_INFO_KEY_NAME,
-  STUDENT_REGISTER_GUIDES,
-} from './constant';
+import { CREATE_TYPE, STUDENT_REGISTER_GUIDES } from './constant';
 import * as S from './style';
 import * as T from './type';
 
@@ -92,13 +89,11 @@ const StudentRegister = () => {
     },
     editType: 'fullRow',
     stopEditingWhenCellsLoseFocus: true,
-    suppressDragLeaveHidesColumns: true,
     rowSelection: 'multiple',
     suppressRowClickSelection: true,
     rowDragManaged: true,
     rowDragMultiRow: true,
     rowDragEntireRow: true,
-    animateRows: true,
     overlayNoRowsTemplate:
       '<div style="padding: 16px; color: gray;">엑셀 파일을 업로드하거나 학생 수를 직접 입력하여 명렬표를 생성해 주세요.</div>',
   };
@@ -117,6 +112,7 @@ const StudentRegister = () => {
   };
 
   const handleCreate = () => {
+    // TODO: 필수값 체크 - 제목, 번호, 이름, 성별
     console.log(studentList);
   };
 


### PR DESCRIPTION
close #131 

### 학생 정보
- 명렬표 조회 페이지 마크업
- 명렬표 목록 조회는 아코디언 UI로 구현
- 대표 설정한 명렬표는 리스트 제일 앞쪽으로 정렬되도록 구현
- mock data로 동적 컬럼 구현 - 백엔드와 논의 필요

### 공통
- `Button concept="text"`일 때 `:hover`, `:active` 등 스타일 추가
- `AgGrid` 폰트가 시스템 기본 폰트를 사용하고 있어 애플리케이션 폰트를 상속하도록 수정
- `AgGrid` 항상 쓰이는 grid 옵션 디폴트로 추가